### PR TITLE
feat: Add msgspec-ext logo and badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
-# msgspec-ext
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msgflux/msgspec-ext/main/assets/msgspec-ext-logo-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/msgflux/msgspec-ext/main/assets/msgspec-ext-logo-light.svg">
+    <img alt="msgspec-ext" src="https://raw.githubusercontent.com/msgflux/msgspec-ext/main/assets/msgspec-ext-logo-light.svg" width="340">
+  </picture>
+</p>
 
-Fast settings management using [msgspec](https://github.com/jcrist/msgspec) - a high-performance serialization library.
+<p align="center">
+  <b>Fast settings management using <a href="https://github.com/jcrist/msgspec">msgspec</a></b> - a high-performance serialization library
+</p>
+
+<p align="center">
+  <a href="https://github.com/msgflux/msgspec-ext/actions/workflows/ci.yml"><img src="https://github.com/msgflux/msgspec-ext/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://pypi.org/project/msgspec-ext/"><img src="https://img.shields.io/pypi/v/msgspec-ext.svg" alt="PyPI"></a>
+  <a href="https://pypi.org/project/msgspec-ext/"><img src="https://img.shields.io/pypi/pyversions/msgspec-ext.svg" alt="Python Versions"></a>
+  <a href="https://github.com/msgflux/msgspec-ext/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
+</p>
 
 ## Features
 

--- a/assets/msgspec-ext-logo-dark.svg
+++ b/assets/msgspec-ext-logo-dark.svg
@@ -1,0 +1,26 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 170 140.4330930481983" width="480" height="280.8661860963966">
+  <!-- svg-source:excalidraw -->
+  <!-- Modified from msgspec logo to add "-ext" - Dark version -->
+
+  <defs>
+    <style>
+      @font-face {
+        font-family: "Virgil";
+        src: url("https://excalidraw.com/Virgil.woff2");
+      }
+      @font-face {
+        font-family: "Cascadia";
+        src: url("https://excalidraw.com/Cascadia.woff2");
+      }
+    </style>
+  </defs>
+  <g transform="translate(0 86.43309304819829) rotate(0 74.5 22)"><text x="0" y="35" font-family="Cascadia, Segoe UI Emoji" font-size="36px" fill="#FFFFFF" text-anchor="start" style="white-space: pre;" direction="ltr">msgspec</text></g>
+  <g transform="translate(123 86.43309304819829) rotate(0 30 22)"><text x="0" y="35" font-family="Cascadia, Segoe UI Emoji" font-size="36px" fill="#a67c00" text-anchor="start" style="white-space: pre;" direction="ltr">-ext</text></g>
+  <g stroke-linecap="round"><g transform="translate(32.39783599432508 94.01908499861165) rotate(0.029772013701078855 48.215665098675686 -41.11647360769149)"><path d="M-1.22 -1.5 C15.89 -27.58, 33.84 -55.74, 50.05 -83.95 M-0.36 0.37 C13.32 -22.25, 25.83 -42.75, 51.23 -83.33 M53.33 -83.11 C67.65 -52.07, 86.66 -20.49, 97.65 -1.24 M52.4 -84.02 C67.73 -54.99, 82.17 -26.19, 95.04 -0.45 M95.98 -0.52 C67.35 0.06, 38.22 -0.14, -1.11 1.79 M96.42 -1.71 C66.83 1.14, 39.67 -0.2, 0.43 0.59" stroke="#a67c00" stroke-width="2" fill="none"></path></g></g>
+  <g stroke-linecap="round"><g transform="translate(18.219822008405913 70.7359699156257) rotate(0 18.679500247428393 -7.904308335528441)"><path d="M0 0 C11.92 -5.04, 23.83 -10.09, 37.36 -15.81 M0 0 C12.98 -5.49, 25.96 -10.98, 37.36 -15.81" stroke="#FFFFFF" stroke-width="1" fill="none"></path></g></g>
+  <g stroke-linecap="round"><g transform="translate(57.323053305918165 55.104453012117375) rotate(0 46.15394434741563 5.6181226555405885)"><path d="M0 0 C10.46 -0.06, 20.91 -0.12, 51.2 -0.28 M0 0 C17.98 -0.1, 35.95 -0.2, 51.2 -0.28 M51.2 -0.28 C67.37 4.36, 83.54 9, 92.31 11.52 M51.2 -0.28 C62.09 2.84, 72.97 5.97, 92.31 11.52" stroke="#FFFFFF" stroke-width="1" fill="none"></path></g></g>
+  <g stroke-linecap="round"><g transform="translate(56.199257109588416 54.93495976287343) rotate(0 45.86948244080588 7.324894095198459)"><path d="M0 0 C18.64 0.76, 37.27 1.51, 52.63 2.13 M0 0 C11.76 0.48, 23.51 0.95, 52.63 2.13 M52.63 2.13 C63.3 5.55, 73.98 8.97, 91.74 14.65 M52.63 2.13 C64.64 5.98, 76.65 9.82, 91.74 14.65" stroke="#FFFFFF" stroke-width="1" fill="none"></path></g></g>
+  <g stroke-linecap="round"><g transform="translate(56.845436327534344 55.04717439786404) rotate(0 45.22944315093423 8.818319104899132)"><path d="M0 0 C15.95 1.27, 31.9 2.55, 53.48 4.27 M0 0 C15.27 1.22, 30.55 2.44, 53.48 4.27 M53.48 4.27 C67.25 9.25, 81.02 14.22, 90.46 17.64 M53.48 4.27 C61.9 7.31, 70.32 10.35, 90.46 17.64" stroke="#FFFFFF" stroke-width="1" fill="none"></path></g></g>
+  <g stroke-linecap="round"><g transform="translate(56.94395645052032 54.42495194663101) rotate(0 46.79398363728728 3.698004785925434)"><path d="M0 0 C10.65 -0.36, 21.3 -0.72, 50.63 -1.71 M0 0 C19.88 -0.67, 39.77 -1.34, 50.63 -1.71 M50.63 -1.71 C64.17 1.7, 77.71 5.11, 93.59 9.1 M50.63 -1.71 C67.41 2.52, 84.19 6.74, 93.59 9.1" stroke="#FFFFFF" stroke-width="1" fill="none"></path></g></g>
+  <g stroke-linecap="round"><g transform="translate(56.3595722753746 54.403787389065116) rotate(0 44.8738657676721 10.66732149786182)"><path d="M0 0 C15.91 2.06, 31.83 4.12, 54.9 7.11 M0 0 C13.84 1.79, 27.69 3.59, 54.9 7.11 M54.9 7.11 C66.92 12.02, 78.95 16.93, 89.75 21.33 M54.9 7.11 C66.02 11.65, 77.13 16.19, 89.75 21.33" stroke="#FFFFFF" stroke-width="1" fill="none"></path></g></g>
+</svg>

--- a/assets/msgspec-ext-logo-light.svg
+++ b/assets/msgspec-ext-logo-light.svg
@@ -1,0 +1,26 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 170 140.4330930481983" width="480" height="280.8661860963966">
+  <!-- svg-source:excalidraw -->
+  <!-- Modified from msgspec logo to add "-ext" -->
+
+  <defs>
+    <style>
+      @font-face {
+        font-family: "Virgil";
+        src: url("https://excalidraw.com/Virgil.woff2");
+      }
+      @font-face {
+        font-family: "Cascadia";
+        src: url("https://excalidraw.com/Cascadia.woff2");
+      }
+    </style>
+  </defs>
+  <g transform="translate(0 86.43309304819829) rotate(0 74.5 22)"><text x="0" y="35" font-family="Cascadia, Segoe UI Emoji" font-size="36px" fill="#000000" text-anchor="start" style="white-space: pre;" direction="ltr">msgspec</text></g>
+  <g transform="translate(123 86.43309304819829) rotate(0 30 22)"><text x="0" y="35" font-family="Cascadia, Segoe UI Emoji" font-size="36px" fill="#a67c00" text-anchor="start" style="white-space: pre;" direction="ltr">-ext</text></g>
+  <g stroke-linecap="round"><g transform="translate(32.39783599432508 94.01908499861165) rotate(0.029772013701078855 48.215665098675686 -41.11647360769149)"><path d="M-1.22 -1.5 C15.89 -27.58, 33.84 -55.74, 50.05 -83.95 M-0.36 0.37 C13.32 -22.25, 25.83 -42.75, 51.23 -83.33 M53.33 -83.11 C67.65 -52.07, 86.66 -20.49, 97.65 -1.24 M52.4 -84.02 C67.73 -54.99, 82.17 -26.19, 95.04 -0.45 M95.98 -0.52 C67.35 0.06, 38.22 -0.14, -1.11 1.79 M96.42 -1.71 C66.83 1.14, 39.67 -0.2, 0.43 0.59" stroke="#a67c00" stroke-width="2" fill="none"></path></g></g>
+  <g stroke-linecap="round"><g transform="translate(18.219822008405913 70.7359699156257) rotate(0 18.679500247428393 -7.904308335528441)"><path d="M0 0 C11.92 -5.04, 23.83 -10.09, 37.36 -15.81 M0 0 C12.98 -5.49, 25.96 -10.98, 37.36 -15.81" stroke="#000000" stroke-width="1" fill="none"></path></g></g>
+  <g stroke-linecap="round"><g transform="translate(57.323053305918165 55.104453012117375) rotate(0 46.15394434741563 5.6181226555405885)"><path d="M0 0 C10.46 -0.06, 20.91 -0.12, 51.2 -0.28 M0 0 C17.98 -0.1, 35.95 -0.2, 51.2 -0.28 M51.2 -0.28 C67.37 4.36, 83.54 9, 92.31 11.52 M51.2 -0.28 C62.09 2.84, 72.97 5.97, 92.31 11.52" stroke="#000000" stroke-width="1" fill="none"></path></g></g>
+  <g stroke-linecap="round"><g transform="translate(56.199257109588416 54.93495976287343) rotate(0 45.86948244080588 7.324894095198459)"><path d="M0 0 C18.64 0.76, 37.27 1.51, 52.63 2.13 M0 0 C11.76 0.48, 23.51 0.95, 52.63 2.13 M52.63 2.13 C63.3 5.55, 73.98 8.97, 91.74 14.65 M52.63 2.13 C64.64 5.98, 76.65 9.82, 91.74 14.65" stroke="#000000" stroke-width="1" fill="none"></path></g></g>
+  <g stroke-linecap="round"><g transform="translate(56.845436327534344 55.04717439786404) rotate(0 45.22944315093423 8.818319104899132)"><path d="M0 0 C15.95 1.27, 31.9 2.55, 53.48 4.27 M0 0 C15.27 1.22, 30.55 2.44, 53.48 4.27 M53.48 4.27 C67.25 9.25, 81.02 14.22, 90.46 17.64 M53.48 4.27 C61.9 7.31, 70.32 10.35, 90.46 17.64" stroke="#000000" stroke-width="1" fill="none"></path></g></g>
+  <g stroke-linecap="round"><g transform="translate(56.94395645052032 54.42495194663101) rotate(0 46.79398363728728 3.698004785925434)"><path d="M0 0 C10.65 -0.36, 21.3 -0.72, 50.63 -1.71 M0 0 C19.88 -0.67, 39.77 -1.34, 50.63 -1.71 M50.63 -1.71 C64.17 1.7, 77.71 5.11, 93.59 9.1 M50.63 -1.71 C67.41 2.52, 84.19 6.74, 93.59 9.1" stroke="#000000" stroke-width="1" fill="none"></path></g></g>
+  <g stroke-linecap="round"><g transform="translate(56.3595722753746 54.403787389065116) rotate(0 44.8738657676721 10.66732149786182)"><path d="M0 0 C15.91 2.06, 31.83 4.12, 54.9 7.11 M0 0 C13.84 1.79, 27.69 3.59, 54.9 7.11 M54.9 7.11 C66.92 12.02, 78.95 16.93, 89.75 21.33 M54.9 7.11 C66.02 11.65, 77.13 16.19, 89.75 21.33" stroke="#000000" stroke-width="1" fill="none"></path></g></g>
+</svg>


### PR DESCRIPTION
## Summary

Adds a professional logo and badges to the msgspec-ext README, improving visual identity and providing quick access to project status.

## Changes

### Logo Design
- ✅ Created light and dark versions of logo based on msgspec logo by jcrist
- ✅ Added golden accent color (#a67c00) for '-ext' text to differentiate from msgspec
- ✅ Applied golden color to decorative elements for cohesive design
- ✅ Optimized spacing and viewBox for better visual appearance
- ✅ Theme-aware display (automatically switches between light/dark based on user preference)

### Badges
- ✅ CI status badge (links to GitHub Actions)
- ✅ PyPI version badge
- ✅ Python versions badge (3.10-3.13)
- ✅ MIT license badge

### Organization
- ✅ Stored logos in `assets/` directory for better project structure
- ✅ Centered layout for professional appearance

## Preview

The logo will display with golden accents for the '-ext' portion, creating a nice visual distinction while maintaining consistency with the msgspec brand.

## Credits

Logo design based on the original msgspec logo by [jcrist](https://github.com/jcrist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)