### PR TITLE
fix: resolve YAML syntax error in merge-bot workflow

### DIFF
--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -409,6 +409,7 @@ jobs:
               core.info('❌ PR is from fork - update not supported');
               core.setOutput('is_fork', 'true');
 
+              const baseBranch = pr.base.ref;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -418,8 +419,8 @@ jobs:
 To update your branch, please run these commands locally:
 
 \`\`\`bash
-git fetch upstream ${pr.base.ref}
-git merge upstream/${pr.base.ref}
+git fetch upstream ${baseBranch}
+git merge upstream/${baseBranch}
 git push
 \`\`\`
 


### PR DESCRIPTION
## Summary

This PR fixes a critical YAML syntax error in the merge-bot workflow that is preventing the workflow from running correctly.

## Problem

The workflow file has an error on **line 420** that causes GitHub Actions to fail parsing the file:

```
Error: You have an error in your yaml syntax on line 420
```

**Root cause**: The JavaScript template literal contains `${pr.base.ref}` which GitHub Actions' YAML parser is interpreting as an attempt at variable interpolation, causing a syntax error.

```javascript
body: `...
\`\`\`bash
git fetch upstream ${pr.base.ref}   // ❌ Causes YAML parsing error
git merge upstream/${pr.base.ref}
git push
\`\`\`
...`
```

## Solution

Extract `pr.base.ref` to a local variable **before** using it in the template literal:

```javascript
const baseBranch = pr.base.ref;      // ✅ Extract to variable
await github.rest.issues.createComment({
  ...
  body: `...
\`\`\`bash
git fetch upstream ${baseBranch}    // ✅ Use local variable
git merge upstream/${baseBranch}
git push
\`\`\`
...`
});
```

## Changes

- Add `const baseBranch = pr.base.ref;` before the comment creation
- Replace `${pr.base.ref}` with `${baseBranch}` in the template string

## Impact

✅ **Fixes workflow validation**: GitHub Actions will accept the workflow file  
✅ **No functional changes**: The behavior remains exactly the same  
✅ **Enables `/update` command**: The update command can now work properly  

## Testing

After merge:
- ✅ Workflow file validation should pass in GitHub Actions
- ✅ The `/update` command can be tested on PR #20

## Related

- Follow-up to PR #19 which introduced the `/update` command
- Discovered when CI failed after PR #19 was merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)