### PR TITLE
fix: resolve all YAML template literal issues in merge-bot workflow

### DIFF
--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -409,6 +409,7 @@ jobs:
               core.info('❌ PR is from fork - update not supported');
               core.setOutput('is_fork', 'true');
 
+              const baseBranch = pr.base.ref;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -418,8 +419,8 @@ jobs:
 To update your branch, please run these commands locally:
 
 \`\`\`bash
-git fetch upstream ${pr.base.ref}
-git merge upstream/${pr.base.ref}
+git fetch upstream ${baseBranch}
+git merge upstream/${baseBranch}
 git push
 \`\`\`
 

--- a/.github/workflows/merge-bot.yml
+++ b/.github/workflows/merge-bot.yml
@@ -410,21 +410,25 @@ jobs:
               core.setOutput('is_fork', 'true');
 
               const baseBranch = pr.base.ref;
+              const forkMessage = [
+                'ℹ️ Update commands are not supported for PRs from forks.',
+                '',
+                'To update your branch, please run these commands locally:',
+                '',
+                '```bash',
+                `git fetch upstream ${baseBranch}`,
+                `git merge upstream/${baseBranch}`,
+                'git push',
+                '```',
+                '',
+                'Or create a new PR from the same repository.'
+              ].join('\n');
+
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.issue.number,
-                body: `ℹ️ Update commands are not supported for PRs from forks.
-
-To update your branch, please run these commands locally:
-
-\`\`\`bash
-git fetch upstream ${baseBranch}
-git merge upstream/${baseBranch}
-git push
-\`\`\`
-
-Or create a new PR from the same repository.`
+                body: forkMessage
               });
 
               return;
@@ -600,13 +604,13 @@ Or create a new PR from the same repository.`
             const baseBranch = '${{ steps.pr_info.outputs.base_branch }}';
             const commitsBehind = '${{ steps.check_update.outputs.commits_behind }}';
 
+            const successMessage = `✅ Branch updated successfully by @${user}!\n\nMerged ${commitsBehind} commit(s) from \`${baseBranch}\`.`;
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: `✅ Branch updated successfully by @${user}!
-
-Merged ${commitsBehind} commit(s) from \`${baseBranch}\`.`
+              body: successMessage
             });
 
             // Add +1 reaction to original comment
@@ -624,21 +628,25 @@ Merged ${commitsBehind} commit(s) from \`${baseBranch}\`.`
           script: |
             const baseBranch = '${{ steps.pr_info.outputs.base_branch }}';
 
+            const failureMessage = [
+              `❌ Failed to update branch with latest changes from \`${baseBranch}\`.`,
+              '',
+              'This usually means there are merge conflicts that need to be resolved manually.',
+              '',
+              'Please update your branch locally:',
+              '```bash',
+              `git fetch origin ${baseBranch}`,
+              `git merge origin/${baseBranch}`,
+              '# Resolve conflicts',
+              'git push',
+              '```'
+            ].join('\n');
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: `❌ Failed to update branch with latest changes from \`${baseBranch}\`.
-
-This usually means there are merge conflicts that need to be resolved manually.
-
-Please update your branch locally:
-\`\`\`bash
-git fetch origin ${baseBranch}
-git merge origin/${baseBranch}
-# Resolve conflicts
-git push
-\`\`\``
+              body: failureMessage
             });
 
             // Add -1 reaction to original comment


### PR DESCRIPTION
## Summary

This PR completely fixes all YAML syntax errors in the merge-bot workflow by replacing problematic template literals with array-based string construction.

## Problem

After PR #21 was merged, the workflow still has multiple YAML parsing errors caused by template literals with backticks inside YAML string literals. GitHub Actions fails to parse the workflow file at multiple locations:

- **Line 420-424**: Fork PR message with code block
- **Line 613**: Success message with inline backticks
- **Line 635-645**: Failure message with code block

**Error pattern**:
```
yaml.scanner.ScannerError: while scanning a simple key
could not find expected ':'
```

## Root Cause

YAML parser struggles with:
- Template literals containing escaped backticks: `\`\`\`bash`
- Multiline strings with complex interpolations
- Nested backticks in template literals inside YAML `script:` blocks

## Solution

Replace all problematic template literals with **array-based string construction**:

### Before (❌ Causes YAML errors):
```javascript
body: `Message here
\`\`\`bash
git fetch upstream ${pr.base.ref}
\`\`\`
More text`
```

### After (✅ Clean and valid):
```javascript
const message = [
  'Message here',
  '```bash',
  `git fetch upstream ${baseBranch}`,
  '```',
  'More text'
].join('\n');

body: message
```

## Changes Made

1. **Fork PR message** (lines 412-425): Array-based construction
2. **Success message** (line 607): Extract to variable before use
3. **Failure message** (lines 631-643): Array-based construction

## Validation

✅ **Python YAML parser**: Validates successfully  
✅ **Node.js syntax check**: JavaScript is valid  
✅ **act (GitHub Actions local runner)**: Workflow parses correctly  

All three validation methods pass!

## Testing

After merge, test with PR #20:
1. Comment `/update` on PR #20
2. Verify the bot can now run successfully
3. Check that messages format correctly with code blocks

## Related

- Fixes issues introduced in PR #19
- Supersedes PR #21 (partial fix)
- Enables testing of `/update` command on PR #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)